### PR TITLE
feat: personalize dashboards and pagination transitions

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,35 +1,40 @@
 import { getServerSession } from "next-auth";
+import type { Session } from "next-auth";
 import { authOptions } from "../../lib/auth";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import AdminInviteForm from "../../components/AdminInviteForm";
+import RoleDashboard from "../../components/RoleDashboard";
+
+interface SessionWithRole extends Session {
+  backendRole?: string;
+}
 
 export default async function AdminHome() {
-  const session = await getServerSession(authOptions);
-  if (!session) redirect('/login');
-  const role = (session as any).backendRole as string | undefined;
-  if (role !== 'Admin') redirect('/');
+  const session = (await getServerSession(authOptions)) as SessionWithRole | null;
+  if (!session) redirect("/login");
+  if (session.backendRole !== "Admin") redirect("/");
 
   return (
-    <main className="mx-auto max-w-5xl p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Espace Administrateur</h1>
+    <RoleDashboard role="Admin" title="Espace Administrateur">
       <section className="rounded-md border border-foreground/15 p-4 space-y-3">
         <div className="text-sm opacity-70">Inviter un Mentor ou Partenaire</div>
         <AdminInviteForm />
       </section>
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <a href="/admin/users" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5">
+        <Link href="/admin/users" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
           <div className="font-medium">Gérer les utilisateurs</div>
           <div className="text-sm opacity-80">Liste et contrôle des rôles</div>
-        </a>
-        <a href="/certificates/issue" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5">
+        </Link>
+        <Link href="/certificates/issue" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
           <div className="font-medium">Émettre un certificat</div>
           <div className="text-sm opacity-80">Mentor/Admin</div>
-        </a>
-        <a href="/mentor" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5">
+        </Link>
+        <Link href="/mentor" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
           <div className="font-medium">Cours et contenus</div>
           <div className="text-sm opacity-80">Accès à l’espace Mentor</div>
-        </a>
+        </Link>
       </section>
-    </main>
+    </RoleDashboard>
   );
 }

--- a/app/apprenant/page.tsx
+++ b/app/apprenant/page.tsx
@@ -1,37 +1,41 @@
 import { getServerSession } from "next-auth";
+import type { Session } from "next-auth";
 import { authOptions } from "../../lib/auth";
 import { getMyProfile } from "../../lib/api/profile";
 import { listMyInscriptions } from "../../lib/api/inscriptions";
+import RoleDashboard from "../../components/RoleDashboard";
+import Link from "next/link";
+
+interface SessionWithToken extends Session {
+  backendAccessToken?: string;
+}
 
 export default async function ApprenantDashboard() {
-  const session = await getServerSession(authOptions);
+  const session = (await getServerSession(authOptions)) as SessionWithToken | null;
   if (!session) {
     return (
-      <main className="p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">Espace Apprenant</h1>
+      <RoleDashboard role="Apprenant" title="Espace Apprenant">
         <p>Vous devez être connecté.</p>
-      </main>
+      </RoleDashboard>
     );
   }
-  const token = (session as any).backendAccessToken as string;
+  const token = session.backendAccessToken || "";
   const profile = await getMyProfile(token).catch(() => null);
   if (!profile?.apprenant) {
     return (
-      <main className="p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">Espace Apprenant</h1>
+      <RoleDashboard role="Apprenant" title="Espace Apprenant">
         <div className="rounded-md border border-foreground/15 p-4">
           <div className="text-sm opacity-80">Aucun profil Apprenant détecté.</div>
-          <a href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm">Créer mon profil</a>
+          <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Créer mon profil</Link>
         </div>
-      </main>
+      </RoleDashboard>
     );
   }
   const inscriptions = await listMyInscriptions(token).catch(() => []);
   const avg = inscriptions.length ? Math.round(inscriptions.reduce((a, b) => a + b.progression, 0) / inscriptions.length) : 0;
 
   return (
-    <main className="p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Espace Apprenant</h1>
+    <RoleDashboard role="Apprenant" title="Espace Apprenant">
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div className="rounded-md border border-foreground/15 p-4">
           <div className="text-xs opacity-60">Cours suivis</div>
@@ -51,17 +55,17 @@ export default async function ApprenantDashboard() {
         <div className="text-sm opacity-70">Mes cours</div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {inscriptions.slice(0, 6).map((ins) => (
-            <a key={ins.id} href={`/courses/${ins.coursId}`} className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5">
+            <Link key={ins.id} href={`/courses/${ins.coursId}`} className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
               <div className="font-medium line-clamp-2">{ins.cours.titre}</div>
               <div className="text-sm opacity-80 mt-1">Progression: {ins.progression}%</div>
-            </a>
+            </Link>
           ))}
         </div>
         <div>
-          <a href="/my/courses" className="inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm">Voir tout</a>
+          <Link href="/my/courses" className="inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Voir tout</Link>
         </div>
       </section>
-    </main>
+    </RoleDashboard>
   );
 }
 

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -16,9 +16,9 @@ export default async function CoursesPage({ searchParams }: { searchParams: Prom
         <div className="text-sm opacity-70">{data.total} cours</div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div key={page} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 animate-page-enter">
         {data.items.map((c) => (
-          <Link key={c.id} href={`/courses/${c.id}`} className="group rounded-lg border border-foreground/10 hover:border-foreground/20 p-4 flex flex-col">
+          <Link key={c.id} href={`/courses/${c.id}`} className="group rounded-lg border border-foreground/10 hover:border-foreground/20 p-4 flex flex-col transition-colors">
             <div className="aspect-video rounded-md bg-foreground/10 mb-3 overflow-hidden">
               {/* placeholder image */}
               {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -35,14 +35,14 @@ export default async function CoursesPage({ searchParams }: { searchParams: Prom
       <div className="mt-6 flex items-center justify-center gap-2">
         <Link
           href={`/courses?page=${Math.max(1, page - 1)}&pageSize=${pageSize}`}
-          className={`px-3 py-2 rounded-md border ${page <= 1 ? "opacity-50 pointer-events-none" : "hover:bg-foreground/5"}`}
+          className={`px-3 py-2 rounded-md border transition-colors ${page <= 1 ? "opacity-50 pointer-events-none" : "hover:bg-foreground/5"}`}
         >
           Précédent
         </Link>
         <span className="text-sm opacity-70">Page {page}</span>
         <Link
           href={`/courses?page=${page + 1}&pageSize=${pageSize}`}
-          className={`px-3 py-2 rounded-md border ${data.items.length < pageSize ? "opacity-50 pointer-events-none" : "hover:bg-foreground/5"}`}
+          className={`px-3 py-2 rounded-md border transition-colors ${data.items.length < pageSize ? "opacity-50 pointer-events-none" : "hover:bg-foreground/5"}`}
         >
           Suivant
         </Link>

--- a/app/mentor/page.tsx
+++ b/app/mentor/page.tsx
@@ -1,30 +1,35 @@
 import { getServerSession } from "next-auth";
+import type { Session } from "next-auth";
 import { authOptions } from "../../lib/auth";
 import { getMyProfile } from "../../lib/api/profile";
 import { listCours } from "../../lib/api/courses";
 import MentorCourseForm from "../../components/MentorCourseForm";
+import RoleDashboard from "../../components/RoleDashboard";
+import Link from "next/link";
+
+interface SessionWithToken extends Session {
+  backendAccessToken?: string;
+}
 
 export default async function MentorDashboard() {
-  const session = await getServerSession(authOptions);
+  const session = (await getServerSession(authOptions)) as SessionWithToken | null;
   if (!session) {
     return (
-      <main className="p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">Espace Mentor</h1>
+      <RoleDashboard role="Mentor" title="Espace Mentor">
         <p>Vous devez être connecté.</p>
-      </main>
+      </RoleDashboard>
     );
   }
-  const token = (session as any).backendAccessToken as string;
+  const token = session.backendAccessToken || "";
   const profile = await getMyProfile(token).catch(() => null);
   if (!profile?.mentor) {
     return (
-      <main className="p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">Espace Mentor</h1>
+      <RoleDashboard role="Mentor" title="Espace Mentor">
         <div className="rounded-md border border-foreground/15 p-4">
           <div className="text-sm opacity-80">Aucun profil Mentor détecté.</div>
-          <a href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm">Créer mon profil</a>
+          <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Créer mon profil</Link>
         </div>
-      </main>
+      </RoleDashboard>
     );
   }
   const mentorId = profile.mentor.id;
@@ -32,8 +37,7 @@ export default async function MentorDashboard() {
   const mine = all.items.filter((c) => c.mentorId === mentorId);
 
   return (
-    <main className="p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Espace Mentor</h1>
+    <RoleDashboard role="Mentor" title="Espace Mentor">
       <section className="rounded-md border border-foreground/15 p-4 space-y-3">
         <div className="text-sm opacity-70">Créer un nouveau cours</div>
         <MentorCourseForm />
@@ -57,13 +61,13 @@ export default async function MentorDashboard() {
         <div className="text-sm opacity-70">Mes cours</div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {mine.map((c) => (
-            <a key={c.id} href={`/courses/${c.id}`} className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5">
+            <Link key={c.id} href={`/courses/${c.id}`} className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
               <div className="font-medium line-clamp-2">{c.titre}</div>
               <div className="text-sm opacity-80 mt-1">{c.duree} min</div>
-            </a>
+            </Link>
           ))}
         </div>
       </section>
-    </main>
+    </RoleDashboard>
   );
 }

--- a/components/RoleDashboard.tsx
+++ b/components/RoleDashboard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+interface RoleDashboardProps {
+  role: "Admin" | "Mentor" | "Apprenant";
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function RoleDashboard({ role, title, children }: RoleDashboardProps) {
+  const bg: Record<RoleDashboardProps["role"], string> = {
+    Admin: "bg-red-50",
+    Mentor: "bg-blue-50",
+    Apprenant: "bg-green-50",
+  };
+  const accent: Record<RoleDashboardProps["role"], string> = {
+    Admin: "text-red-700",
+    Mentor: "text-blue-700",
+    Apprenant: "text-green-700",
+  };
+  return (
+    <main className={`mx-auto max-w-5xl p-6 space-y-6 ${bg[role]}`}>
+      <h1 className={`text-2xl font-semibold ${accent[role]}`}>{title}</h1>
+      {children}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- style each dashboard by role using shared component
- add fade-in animation and link transitions to course pagination
- convert dashboard links to Next.js Link components and type sessions

## Testing
- `npm run lint` *(fails: many existing `any` warnings across project)*

------
https://chatgpt.com/codex/tasks/task_e_68bc024fa948832d8384efde8aef0b18