### PR TITLE
feat: add admin model and refresh role dashboards

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -17,20 +17,20 @@ export default async function AdminHome() {
 
   return (
     <RoleDashboard role="Admin" title="Espace Administrateur">
-      <section className="rounded-md border border-foreground/15 p-4 space-y-3">
+      <section className="card p-4 space-y-3">
         <div className="text-sm opacity-70">Inviter un Mentor ou Partenaire</div>
         <AdminInviteForm />
       </section>
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <Link href="/admin/users" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
+        <Link href="/admin/users" className="card p-4 hover:bg-foreground/5 transition-colors">
           <div className="font-medium">Gérer les utilisateurs</div>
           <div className="text-sm opacity-80">Liste et contrôle des rôles</div>
         </Link>
-        <Link href="/certificates/issue" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
+        <Link href="/certificates/issue" className="card p-4 hover:bg-foreground/5 transition-colors">
           <div className="font-medium">Émettre un certificat</div>
           <div className="text-sm opacity-80">Mentor/Admin</div>
         </Link>
-        <Link href="/mentor" className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
+        <Link href="/mentor" className="card p-4 hover:bg-foreground/5 transition-colors">
           <div className="font-medium">Cours et contenus</div>
           <div className="text-sm opacity-80">Accès à l’espace Mentor</div>
         </Link>

--- a/app/apprenant/page.tsx
+++ b/app/apprenant/page.tsx
@@ -23,29 +23,29 @@ export default async function ApprenantDashboard() {
   const profile = await getMyProfile(token).catch(() => null);
   if (!profile?.apprenant) {
     return (
-      <RoleDashboard role="Apprenant" title="Espace Apprenant">
-        <div className="rounded-md border border-foreground/15 p-4">
-          <div className="text-sm opacity-80">Aucun profil Apprenant détecté.</div>
-          <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Créer mon profil</Link>
-        </div>
-      </RoleDashboard>
-    );
-  }
+        <RoleDashboard role="Apprenant" title="Espace Apprenant">
+          <div className="card p-4">
+            <div className="text-sm opacity-80">Aucun profil Apprenant détecté.</div>
+            <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Créer mon profil</Link>
+          </div>
+        </RoleDashboard>
+      );
+    }
   const inscriptions = await listMyInscriptions(token).catch(() => []);
   const avg = inscriptions.length ? Math.round(inscriptions.reduce((a, b) => a + b.progression, 0) / inscriptions.length) : 0;
 
   return (
     <RoleDashboard role="Apprenant" title="Espace Apprenant">
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <div className="rounded-md border border-foreground/15 p-4">
+        <div className="card p-4">
           <div className="text-xs opacity-60">Cours suivis</div>
           <div className="text-2xl font-semibold">{inscriptions.length}</div>
         </div>
-        <div className="rounded-md border border-foreground/15 p-4">
+        <div className="card p-4">
           <div className="text-xs opacity-60">Progression moyenne</div>
           <div className="text-2xl font-semibold">{avg}%</div>
         </div>
-        <div className="rounded-md border border-foreground/15 p-4">
+        <div className="card p-4">
           <div className="text-xs opacity-60">Notifications</div>
           <div className="text-2xl font-semibold">–</div>
         </div>
@@ -55,7 +55,7 @@ export default async function ApprenantDashboard() {
         <div className="text-sm opacity-70">Mes cours</div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {inscriptions.slice(0, 6).map((ins) => (
-            <Link key={ins.id} href={`/courses/${ins.coursId}`} className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
+            <Link key={ins.id} href={`/courses/${ins.coursId}`} className="card p-4 hover:bg-foreground/5 transition-colors">
               <div className="font-medium line-clamp-2">{ins.cours.titre}</div>
               <div className="text-sm opacity-80 mt-1">Progression: {ins.progression}%</div>
             </Link>

--- a/app/mentor/page.tsx
+++ b/app/mentor/page.tsx
@@ -24,34 +24,34 @@ export default async function MentorDashboard() {
   const profile = await getMyProfile(token).catch(() => null);
   if (!profile?.mentor) {
     return (
-      <RoleDashboard role="Mentor" title="Espace Mentor">
-        <div className="rounded-md border border-foreground/15 p-4">
-          <div className="text-sm opacity-80">Aucun profil Mentor détecté.</div>
-          <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Créer mon profil</Link>
-        </div>
-      </RoleDashboard>
-    );
-  }
+        <RoleDashboard role="Mentor" title="Espace Mentor">
+          <div className="card p-4">
+            <div className="text-sm opacity-80">Aucun profil Mentor détecté.</div>
+            <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Créer mon profil</Link>
+          </div>
+        </RoleDashboard>
+      );
+    }
   const mentorId = profile.mentor.id;
   const all = await listCours({ page: 1, pageSize: 100 }).catch(() => ({ items: [], total: 0, page: 1, pageSize: 100 }));
   const mine = all.items.filter((c) => c.mentorId === mentorId);
 
   return (
     <RoleDashboard role="Mentor" title="Espace Mentor">
-      <section className="rounded-md border border-foreground/15 p-4 space-y-3">
+      <section className="card p-4 space-y-3">
         <div className="text-sm opacity-70">Créer un nouveau cours</div>
         <MentorCourseForm />
       </section>
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-        <div className="rounded-md border border-foreground/15 p-4">
+        <div className="card p-4">
           <div className="text-xs opacity-60">Cours publiés</div>
           <div className="text-2xl font-semibold">{mine.length}</div>
         </div>
-        <div className="rounded-md border border-foreground/15 p-4">
+        <div className="card p-4">
           <div className="text-xs opacity-60">Modules/Leçons</div>
           <div className="text-2xl font-semibold">–</div>
         </div>
-        <div className="rounded-md border border-foreground/15 p-4">
+        <div className="card p-4">
           <div className="text-xs opacity-60">Quizzes</div>
           <div className="text-2xl font-semibold">–</div>
         </div>
@@ -61,7 +61,7 @@ export default async function MentorDashboard() {
         <div className="text-sm opacity-70">Mes cours</div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {mine.map((c) => (
-            <Link key={c.id} href={`/courses/${c.id}`} className="rounded-md border border-foreground/10 p-4 hover:bg-foreground/5 transition-colors">
+            <Link key={c.id} href={`/courses/${c.id}`} className="card p-4 hover:bg-foreground/5 transition-colors">
               <div className="font-medium line-clamp-2">{c.titre}</div>
               <div className="text-sm opacity-80 mt-1">{c.duree} min</div>
             </Link>

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   Apprenant          Apprenant?
   Mentor             Mentor?
   Partenaire         Partenaire?
+  Admin              Admin?
   Posts              Post[]
   Notifications      Notification[]
   messagesSent       Message[]            @relation("SenderMessages")
@@ -74,6 +75,12 @@ model Partenaire {
   user             User           @relation(fields: [userId], references: [id])
   posts            Post[]
   notifications    Notification[]
+}
+
+model Admin {
+  id      Int @id @default(autoincrement())
+  userId  Int @unique
+  user    User @relation(fields: [userId], references: [id])
 }
 
 model Cours {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -6,31 +6,43 @@ dotenv.config();
 const prisma = new PrismaClient();
 
 async function main() {
-  const adminEmail = process.env.ADMIN_EMAIL || "admin@eduimpact.test";
-  const adminPassword = process.env.ADMIN_PASSWORD || "ChangeMe123!";
+  const defaultPassword = process.env.ADMIN_PASSWORD || "ChangeMe123!";
+  const admins = [
+    {
+      firstName: "Admin",
+      lastName: "EduImpact",
+      email: process.env.ADMIN_EMAIL || "admin@eduimpact.test",
+    },
+    {
+      firstName: "Alice",
+      lastName: "Admin",
+      email: "admin2@eduimpact.test",
+    },
+  ];
 
-  const existing = await prisma.user.findUnique({ where: { email: adminEmail } });
-  if (!existing) {
-    const salt = await bcrypt.genSalt(10);
-    const password = await bcrypt.hash(adminPassword, salt);
-    await prisma.user.create({
-      data: {
-        firstName: "Admin",
-        lastName: "EduImpact",
-        email: adminEmail,
-        address: "-",
-        phone: "-",
-        status: true,
-        photoUrl: "-",
-        password,
-        role: Role.Admin,
-      },
-    });
-    // eslint-disable-next-line no-console
-    console.log(`Seed: admin créé (${adminEmail})`);
-  } else {
-    // eslint-disable-next-line no-console
-    console.log("Seed: admin déjà présent");
+  for (const a of admins) {
+    const existing = await prisma.user.findUnique({ where: { email: a.email } });
+    if (!existing) {
+      const salt = await bcrypt.genSalt(10);
+      const password = await bcrypt.hash(defaultPassword, salt);
+      await prisma.user.create({
+        data: {
+          ...a,
+          address: "-",
+          phone: "-",
+          status: true,
+          photoUrl: "-",
+          password,
+          role: Role.Admin,
+          Admin: { create: {} },
+        },
+      });
+      // eslint-disable-next-line no-console
+      console.log(`Seed: admin créé (${a.email})`);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(`Seed: admin déjà présent (${a.email})`);
+    }
   }
 }
 

--- a/components/RoleDashboard.tsx
+++ b/components/RoleDashboard.tsx
@@ -7,19 +7,17 @@ interface RoleDashboardProps {
 }
 
 export default function RoleDashboard({ role, title, children }: RoleDashboardProps) {
-  const bg: Record<RoleDashboardProps["role"], string> = {
-    Admin: "bg-red-50",
-    Mentor: "bg-blue-50",
-    Apprenant: "bg-green-50",
-  };
-  const accent: Record<RoleDashboardProps["role"], string> = {
-    Admin: "text-red-700",
-    Mentor: "text-blue-700",
-    Apprenant: "text-green-700",
+  const colors: Record<RoleDashboardProps["role"], { bg: string; accent: string }> = {
+    Admin: { bg: "bg-red-50", accent: "text-red-700" },
+    Mentor: { bg: "bg-blue-50", accent: "text-blue-700" },
+    Apprenant: { bg: "bg-green-50", accent: "text-green-700" },
   };
   return (
-    <main className={`mx-auto max-w-5xl p-6 space-y-6 ${bg[role]}`}>
-      <h1 className={`text-2xl font-semibold ${accent[role]}`}>{title}</h1>
+    <main className="mx-auto max-w-5xl p-6 space-y-6">
+      <header className={`rounded-lg p-6 shadow-sm ${colors[role].bg}`}>
+        <h1 className={`text-2xl font-semibold ${colors[role].accent}`}>{title}</h1>
+        <p className="text-sm opacity-70">Bienvenue dans votre espace {role.toLowerCase()}.</p>
+      </header>
       {children}
     </main>
   );


### PR DESCRIPTION
## Summary
- add dedicated Admin table and link it to users
- seed default admin accounts for easier access
- restyle role dashboards with unified card layouts

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm --prefix backend run prisma:generate`


------
https://chatgpt.com/codex/tasks/task_e_68bc0af727bc832db768fb2b88e677c1