### PR TITLE
feat: set apprenant as default user role

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,7 +17,7 @@ model User {
   status    Boolean
   photoUrl  String   @db.VarChar(255)
   password  String   @db.VarChar(255)
-  role      Role     @default(Admin)
+  role      Role     @default(Apprenant)
   createdAt DateTime @default(now()) @db.Timestamp(6)
   updatedAt DateTime @updatedAt @db.Timestamp(6)
 


### PR DESCRIPTION
## Summary
- default new users to Apprenant in Prisma schema

## Testing
- `npm run prisma:generate`
- `npm run prisma:push` (fails: Environment variable not found: DATABASE_URL)
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any. Specify a different type.)

------
https://chatgpt.com/codex/tasks/task_e_68bc0fe6a428832da2cb931ade5edc4d