### PR TITLE
feat: add document manager and search to role dashboards

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import AdminInviteForm from "../../components/AdminInviteForm";
 import RoleDashboard from "../../components/RoleDashboard";
+import DocumentManager from "../../components/DocumentManager";
 
 interface SessionWithRole extends Session {
   backendRole?: string;
@@ -17,6 +18,7 @@ export default async function AdminHome() {
 
   return (
     <RoleDashboard role="Admin" title="Espace Administrateur">
+      <DocumentManager />
       <section className="card p-4 space-y-3">
         <div className="text-sm opacity-70">Inviter un Mentor ou Partenaire</div>
         <AdminInviteForm />

--- a/app/apprenant/page.tsx
+++ b/app/apprenant/page.tsx
@@ -5,6 +5,8 @@ import { getMyProfile } from "../../lib/api/profile";
 import { listMyInscriptions } from "../../lib/api/inscriptions";
 import RoleDashboard from "../../components/RoleDashboard";
 import Link from "next/link";
+import DocumentManager from "../../components/DocumentManager";
+import SearchList from "../../components/SearchList";
 
 interface SessionWithToken extends Session {
   backendAccessToken?: string;
@@ -36,6 +38,7 @@ export default async function ApprenantDashboard() {
 
   return (
     <RoleDashboard role="Apprenant" title="Espace Apprenant">
+      <DocumentManager />
       <section className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div className="card p-4">
           <div className="text-xs opacity-60">Cours suivis</div>
@@ -53,14 +56,14 @@ export default async function ApprenantDashboard() {
 
       <section className="space-y-3">
         <div className="text-sm opacity-70">Mes cours</div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {inscriptions.slice(0, 6).map((ins) => (
-            <Link key={ins.id} href={`/courses/${ins.coursId}`} className="card p-4 hover:bg-foreground/5 transition-colors">
-              <div className="font-medium line-clamp-2">{ins.cours.titre}</div>
-              <div className="text-sm opacity-80 mt-1">Progression: {ins.progression}%</div>
-            </Link>
-          ))}
-        </div>
+        <SearchList
+          items={inscriptions.map((ins) => ({
+            id: ins.id,
+            label: ins.cours.titre,
+            href: `/courses/${ins.coursId}`,
+            meta: `Progression: ${ins.progression}%`,
+          }))}
+        />
         <div>
           <Link href="/my/courses" className="inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm transition-colors">Voir tout</Link>
         </div>

--- a/app/mentor/page.tsx
+++ b/app/mentor/page.tsx
@@ -6,6 +6,8 @@ import { listCours } from "../../lib/api/courses";
 import MentorCourseForm from "../../components/MentorCourseForm";
 import RoleDashboard from "../../components/RoleDashboard";
 import Link from "next/link";
+import DocumentManager from "../../components/DocumentManager";
+import SearchList from "../../components/SearchList";
 
 interface SessionWithToken extends Session {
   backendAccessToken?: string;
@@ -38,6 +40,7 @@ export default async function MentorDashboard() {
 
   return (
     <RoleDashboard role="Mentor" title="Espace Mentor">
+      <DocumentManager />
       <section className="card p-4 space-y-3">
         <div className="text-sm opacity-70">Créer un nouveau cours</div>
         <MentorCourseForm />
@@ -59,14 +62,7 @@ export default async function MentorDashboard() {
 
       <section className="space-y-3">
         <div className="text-sm opacity-70">Mes cours</div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {mine.map((c) => (
-            <Link key={c.id} href={`/courses/${c.id}`} className="card p-4 hover:bg-foreground/5 transition-colors">
-              <div className="font-medium line-clamp-2">{c.titre}</div>
-              <div className="text-sm opacity-80 mt-1">{c.duree} min</div>
-            </Link>
-          ))}
-        </div>
+        <SearchList items={mine.map((c) => ({ id: c.id, label: c.titre, href: `/courses/${c.id}`, meta: `${c.duree} min` }))} />
       </section>
     </RoleDashboard>
   );

--- a/app/partenaire/page.tsx
+++ b/app/partenaire/page.tsx
@@ -4,15 +4,17 @@ import { getMyProfile } from "../../lib/api/profile";
 import { listPosts } from "../../lib/api/posts";
 import PartnerPostForm from "../../components/PartnerPostForm";
 import Link from "next/link";
+import RoleDashboard from "../../components/RoleDashboard";
+import DocumentManager from "../../components/DocumentManager";
+import SearchList from "../../components/SearchList";
 
 export default async function PartnerDashboard() {
   const session = await getServerSession(authOptions);
   if (!session) {
     return (
-      <main className="p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">Espace Partenaire</h1>
+      <RoleDashboard role="Partenaire" title="Espace Partenaire">
         <p>Vous devez être connecté.</p>
-      </main>
+      </RoleDashboard>
     );
   }
   const token = (session as BackendFields).backendAccessToken as string;
@@ -20,22 +22,20 @@ export default async function PartnerDashboard() {
   const profile = await getMyProfile(token).catch(() => null);
   if (!profile?.partenaire) {
     return (
-      <main className="p-6 space-y-4">
-        <h1 className="text-2xl font-semibold">Espace Partenaire</h1>
-        <div className="rounded-md border border-foreground/15 p-4">
+      <RoleDashboard role="Partenaire" title="Espace Partenaire">
+        <div className="card p-4">
           <div className="text-sm opacity-80">Aucun profil Partenaire détecté.</div>
           <Link href="/profile" className="mt-2 inline-flex h-9 px-3 items-center rounded-md border border-foreground/20 hover:bg-foreground/5 text-sm">Créer mon profil</Link>
         </div>
-      </main>
+      </RoleDashboard>
     );
   }
   const posts = await listPosts().catch(() => []);
   const mine = posts.filter((p) => p.userId === userId);
 
   return (
-    <main className="p-6 space-y-6">
-      <h1 className="text-2xl font-semibold">Espace Partenaire</h1>
-
+    <RoleDashboard role="Partenaire" title="Espace Partenaire">
+      <DocumentManager />
       <section className="rounded-md border border-foreground/15 p-4 space-y-3">
         <div className="text-sm opacity-70">Publier une opportunité</div>
         <PartnerPostForm />
@@ -43,18 +43,15 @@ export default async function PartnerDashboard() {
 
       <section className="space-y-3">
         <div className="text-sm opacity-70">Mes publications</div>
-        <div className="grid grid-cols-1 gap-3">
-          {mine.map((p) => (
-            <div key={p.id} className="rounded-md border border-foreground/10 p-4">
-              <div className="text-sm opacity-70">{p.typeOportunite} • {p.status}</div>
-              <div className="font-medium">{p.title}</div>
-              <div className="text-sm opacity-80 line-clamp-2">{p.content}</div>
-            </div>
-          ))}
-          {mine.length === 0 && <div className="text-sm opacity-70">Aucune publication pour l&apos;instant.</div>}
-        </div>
+        <SearchList
+          items={mine.map((p) => ({
+            id: p.id,
+            label: p.title,
+            meta: `${p.typeOportunite} • ${p.status}`,
+          }))}
+        />
       </section>
-    </main>
+    </RoleDashboard>
   );
 }
 

--- a/components/DocumentManager.tsx
+++ b/components/DocumentManager.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+
+interface DocItem { name: string; url: string; }
+
+export default function DocumentManager() {
+  const [docs, setDocs] = useState<DocItem[]>([]);
+  const [query, setQuery] = useState('');
+
+  const onUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []).map((f) => ({ name: f.name, url: URL.createObjectURL(f) }));
+    setDocs((prev) => [...prev, ...files]);
+  };
+
+  const remove = (url: string) => {
+    setDocs((prev) => prev.filter((d) => d.url !== url));
+  };
+
+  const filtered = docs.filter((d) => d.name.toLowerCase().includes(query.toLowerCase()));
+
+  return (
+    <div className="card p-4 space-y-3">
+      <div className="text-sm opacity-70">Documents</div>
+      <input type="file" multiple onChange={onUpload} className="block text-sm" />
+      <input
+        type="text"
+        placeholder="Rechercher…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="w-full rounded-md border border-foreground/20 bg-transparent px-3 py-2 text-sm"
+      />
+      <ul className="space-y-2">
+        {filtered.map((d) => (
+          <li key={d.url} className="flex items-center justify-between rounded-md border border-foreground/10 px-3 py-2 text-sm">
+            <span className="truncate mr-2" title={d.name}>{d.name}</span>
+            <span className="flex gap-2">
+              <a href={d.url} download={d.name} className="text-blue-600 hover:underline">Télécharger</a>
+              <button onClick={() => remove(d.url)} className="text-red-600">×</button>
+            </span>
+          </li>
+        ))}
+        {filtered.length === 0 && <li className="text-sm opacity-70">Aucun document.</li>}
+      </ul>
+    </div>
+  );
+}
+

--- a/components/RoleDashboard.tsx
+++ b/components/RoleDashboard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 interface RoleDashboardProps {
-  role: "Admin" | "Mentor" | "Apprenant";
+  role: "Admin" | "Mentor" | "Apprenant" | "Partenaire";
   title: string;
   children: React.ReactNode;
 }
@@ -11,6 +11,7 @@ export default function RoleDashboard({ role, title, children }: RoleDashboardPr
     Admin: { bg: "bg-red-50", accent: "text-red-700" },
     Mentor: { bg: "bg-blue-50", accent: "text-blue-700" },
     Apprenant: { bg: "bg-green-50", accent: "text-green-700" },
+    Partenaire: { bg: "bg-purple-50", accent: "text-purple-700" },
   };
   return (
     <main className="mx-auto max-w-5xl p-6 space-y-6">

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+export default function SearchBar({ value, onChange }: Props) {
+  return (
+    <input
+      type="text"
+      placeholder="Rechercher…"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded-md border border-foreground/20 bg-transparent px-3 py-2 text-sm"
+    />
+  );
+}

--- a/components/SearchList.tsx
+++ b/components/SearchList.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import SearchBar from './SearchBar';
+
+interface Item { id: number | string; label: string; href?: string; meta?: string; }
+
+export default function SearchList({ items }: { items: Item[] }) {
+  const [q, setQ] = useState('');
+  const filtered = items.filter((i) => i.label.toLowerCase().includes(q.toLowerCase()));
+  return (
+    <div className="space-y-3">
+      <SearchBar value={q} onChange={setQ} />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {filtered.map((i) => (
+          i.href ? (
+            <Link key={i.id} href={i.href} className="card p-4 hover:bg-foreground/5 transition-colors">
+              <div className="font-medium line-clamp-2">{i.label}</div>
+              {i.meta && <div className="text-sm opacity-80 mt-1">{i.meta}</div>}
+            </Link>
+          ) : (
+            <div key={i.id} className="card p-4">
+              <div className="font-medium line-clamp-2">{i.label}</div>
+              {i.meta && <div className="text-sm opacity-80 mt-1">{i.meta}</div>}
+            </div>
+          )
+        ))}
+        {filtered.length === 0 && <div className="text-sm opacity-70">Aucun résultat</div>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared DocumentManager with upload, download and search
- extend RoleDashboard for Partenaire role styling
- integrate document management and searchable lists into all dashboards

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch Google fonts; existing quiz manage page requires `use client`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc65244100832d8622897316b22e1e